### PR TITLE
Classify <script type="speculationrules"> as Weight 1 (PREFETCH_PRERENDER)

### DIFF
--- a/docs/src/content/docs/user/rules.mdx
+++ b/docs/src/content/docs/user/rules.mdx
@@ -206,6 +206,10 @@ Because they are not needed for the current page, capo.js recommends placing the
 
 While `dns-prefetch` also deals with connection setup like [`preconnect`](#link-relpreconnect), it is placed here because it is a speculative hint for future navigations or low-priority resources, whereas `preconnect` is for resources needed immediately.
 
+### `<script type=speculationrules>`
+
+The [Speculation Rules API](https://developer.mozilla.org/docs/Web/HTML/Element/script/type/speculationrules) provides a modern, JSON-based declarative syntax for speculatively prefetching and prerendering future navigations. Like prefetch and prerender link tags, they are placed here so their speculative downloads do not compete for bandwidth with resources required for the current page.
+
 ## <InlineCapoWeightBars weight="1" /> 1. Everything else
 
 Any other elements found in the `<head>` that don't match the above categories are given the lowest weight.

--- a/src/lib/rules.js
+++ b/src/lib/rules.js
@@ -149,8 +149,11 @@ export function isSyncScript(element, adapter) {
   }
 
   const type = adapter.getAttribute(element, "type");
-  if (type && type.toLowerCase().includes("json")) {
-    return false;
+  if (type) {
+    const normalizedType = type.toLowerCase().trim();
+    if (normalizedType.includes("json") || normalizedType === "speculationrules") {
+      return false;
+    }
   }
 
   return true;
@@ -235,13 +238,20 @@ export function isDeferScript(element, adapter) {
 }
 
 /**
- * Check if element is prefetch/dns-prefetch/prerender link
+ * Check if element is prefetch/dns-prefetch/prerender link or speculationrules script
  * @param {any} element
  * @param {AdapterInterface} adapter
  * @returns {boolean}
  */
 export function isPrefetchPrerender(element, adapter) {
-  if (adapter.getTagName(element) !== "link") {
+  const tagName = adapter.getTagName(element);
+
+  if (tagName === "script") {
+    const type = adapter.getAttribute(element, "type");
+    return type?.toLowerCase().trim() === "speculationrules";
+  }
+
+  if (tagName !== "link") {
     return false;
   }
 

--- a/tests/lib/rules.test.js
+++ b/tests/lib/rules.test.js
@@ -201,6 +201,11 @@ describe("rules.js", () => {
       const element = createElement('<script type="application/json">{"key": "value"}</script>');
       assert.strictEqual(isSyncScript(element, adapter), false);
     });
+
+    it("should NOT detect speculationrules scripts", () => {
+      const element = createElement('<script type="speculationrules">{"prefetch": []}</script>');
+      assert.strictEqual(isSyncScript(element, adapter), false);
+    });
   });
 
   describe("isSyncStyles", () => {
@@ -305,6 +310,11 @@ describe("rules.js", () => {
       assert.strictEqual(isPrefetchPrerender(element, adapter), true);
     });
 
+    it("should detect speculationrules scripts", () => {
+      const element = createElement('<script type="speculationrules">{"prefetch": []}</script>');
+      assert.strictEqual(isPrefetchPrerender(element, adapter), true);
+    });
+
     it("should NOT detect preconnect links", () => {
       const element = createElement('<link rel="preconnect" href="https://fonts.googleapis.com">');
       assert.strictEqual(isPrefetchPrerender(element, adapter), false);
@@ -400,6 +410,11 @@ describe("rules.js", () => {
         html: '<link rel="prefetch" href="next.html">',
         expected: ElementWeights.PREFETCH_PRERENDER,
         type: "PREFETCH_PRERENDER",
+      },
+      {
+        html: '<script type="speculationrules">{"prefetch": []}</script>',
+        expected: ElementWeights.PREFETCH_PRERENDER,
+        type: "PREFETCH_PRERENDER (speculationrules)",
       },
       { html: '<meta name="description" content="test">', expected: ElementWeights.OTHER, type: "OTHER" },
       { html: '<link rel="icon" href="favicon.ico">', expected: ElementWeights.OTHER, type: "OTHER (icon)" },


### PR DESCRIPTION
### Summary

Fixes #139

Classifies `<script type="speculationrules">` under **Weight 1 (`PREFETCH_PRERENDER`)** rather than being treated as a synchronous, parser-blocking script (Weight 5).

### Changes

1. **`isSyncScript`** ([`src/lib/rules.js`](file:///Users/rviscomi/git/capo.js/src/lib/rules.js)): Excluded scripts with `type="speculationrules"`.
2. **`isPrefetchPrerender`** ([`src/lib/rules.js`](file:///Users/rviscomi/git/capo.js/src/lib/rules.js)): Added detector logic matching `<script type="speculationrules">`.
3. **Documentation** ([`docs/src/content/docs/user/rules.mdx`](file:///Users/rviscomi/git/capo.js/docs/src/content/docs/user/rules.mdx)): Added `<script type=speculationrules>` under the prefetch and prerender rules section with an explanation of why speculative rules belong in this tier.
4. **Unit Tests** ([`tests/lib/rules.test.js`](file:///Users/rviscomi/git/capo.js/tests/lib/rules.test.js)): Added assertions verifying that `isSyncScript` returns `false`, `isPrefetchPrerender` returns `true`, and `getWeight` returns `1` for `<script type="speculationrules">`.