### PR TITLE
Automate Web Store publishing for Chrome and Firefox

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,48 @@
+name: Publish Extension to Web Stores
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Build extension packages
+        run: |
+          npm run build
+          npm run package:source
+
+      - name: Publish to Chrome Web Store
+        run: node scripts/publish-chrome.js
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+
+      - name: Submit to Firefox Add-ons (AMO)
+        run: |
+          npx --yes web-ext sign \
+            --channel=listed \
+            --source-dir=dist/firefox \
+            --artifacts-dir=dist \
+            --upload-source-code=dist/source.zip \
+            --api-key="${{ secrets.FIREFOX_API_KEY }}" \
+            --api-secret="${{ secrets.FIREFOX_API_SECRET }}"

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,4 @@ crx.zip
 .parcel-cache
 dist/
 *.tsbuildinfo
+.env

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,19 +1,9 @@
 import fs from "fs";
 import path from "path";
 
-const {
-  CHROME_CLIENT_ID,
-  CHROME_CLIENT_SECRET,
-  CHROME_REFRESH_TOKEN,
-  CHROME_EXTENSION_ID,
-} = process.env;
+const { CHROME_CLIENT_ID, CHROME_CLIENT_SECRET, CHROME_REFRESH_TOKEN, CHROME_EXTENSION_ID } = process.env;
 
-const requiredEnv = [
-  "CHROME_CLIENT_ID",
-  "CHROME_CLIENT_SECRET",
-  "CHROME_REFRESH_TOKEN",
-  "CHROME_EXTENSION_ID",
-];
+const requiredEnv = ["CHROME_CLIENT_ID", "CHROME_CLIENT_SECRET", "CHROME_REFRESH_TOKEN", "CHROME_EXTENSION_ID"];
 
 const missingEnv = requiredEnv.filter((name) => !process.env[name]);
 if (missingEnv.length > 0) {
@@ -57,17 +47,14 @@ async function uploadPackage(accessToken) {
   console.log(`📦 Uploading package (${ZIP_PATH}) to Chrome Web Store item ${CHROME_EXTENSION_ID}...`);
   const zipBuffer = fs.readFileSync(ZIP_PATH);
 
-  const res = await fetch(
-    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}`,
-    {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-goog-api-version": "2",
-      },
-      body: zipBuffer,
-    }
-  );
+  const res = await fetch(`https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "x-goog-api-version": "2",
+    },
+    body: zipBuffer,
+  });
 
   const data = await res.json();
   if (!res.ok || data.uploadState !== "SUCCESS") {
@@ -80,17 +67,14 @@ async function uploadPackage(accessToken) {
 
 async function publishItem(accessToken) {
   console.log(`🚀 Submitting item ${CHROME_EXTENSION_ID} for review / publishing...`);
-  const res = await fetch(
-    `https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "x-goog-api-version": "2",
-        "Content-Length": "0",
-      },
-    }
-  );
+  const res = await fetch(`https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "x-goog-api-version": "2",
+      "Content-Length": "0",
+    },
+  });
 
   const data = await res.json();
   if (!res.ok || (Array.isArray(data.status) && !data.status.includes("OK"))) {

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,0 +1,116 @@
+import fs from "fs";
+import path from "path";
+
+const {
+  CHROME_CLIENT_ID,
+  CHROME_CLIENT_SECRET,
+  CHROME_REFRESH_TOKEN,
+  CHROME_EXTENSION_ID,
+} = process.env;
+
+const requiredEnv = [
+  "CHROME_CLIENT_ID",
+  "CHROME_CLIENT_SECRET",
+  "CHROME_REFRESH_TOKEN",
+  "CHROME_EXTENSION_ID",
+];
+
+const missingEnv = requiredEnv.filter((name) => !process.env[name]);
+if (missingEnv.length > 0) {
+  console.error(`❌ Error: Missing required environment variables: ${missingEnv.join(", ")}`);
+  process.exit(1);
+}
+
+const ZIP_PATH = path.resolve("dist/chrome.zip");
+if (!fs.existsSync(ZIP_PATH)) {
+  console.error(`❌ Error: Zip file not found at ${ZIP_PATH}. Run 'npm run build' first.`);
+  process.exit(1);
+}
+
+async function getAccessToken() {
+  console.log("🔑 Requesting OAuth2 access token...");
+  const params = new URLSearchParams({
+    client_id: CHROME_CLIENT_ID,
+    client_secret: CHROME_CLIENT_SECRET,
+    refresh_token: CHROME_REFRESH_TOKEN,
+    grant_type: "refresh_token",
+  });
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Failed to obtain access token (HTTP ${res.status}): ${errText}`);
+  }
+
+  const data = await res.json();
+  return data.access_token;
+}
+
+async function uploadPackage(accessToken) {
+  console.log(`📦 Uploading package (${ZIP_PATH}) to Chrome Web Store item ${CHROME_EXTENSION_ID}...`);
+  const zipBuffer = fs.readFileSync(ZIP_PATH);
+
+  const res = await fetch(
+    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "x-goog-api-version": "2",
+      },
+      body: zipBuffer,
+    }
+  );
+
+  const data = await res.json();
+  if (!res.ok || data.uploadState !== "SUCCESS") {
+    throw new Error(`Package upload failed: ${JSON.stringify(data, null, 2)}`);
+  }
+
+  console.log("✅ Package uploaded successfully.");
+  return data;
+}
+
+async function publishItem(accessToken) {
+  console.log(`🚀 Submitting item ${CHROME_EXTENSION_ID} for review / publishing...`);
+  const res = await fetch(
+    `https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "x-goog-api-version": "2",
+        "Content-Length": "0",
+      },
+    }
+  );
+
+  const data = await res.json();
+  if (!res.ok || (Array.isArray(data.status) && !data.status.includes("OK"))) {
+    throw new Error(`Publish failed: ${JSON.stringify(data, null, 2)}`);
+  }
+
+  console.log("✅ Item submitted to Chrome Web Store successfully:", data);
+  return data;
+}
+
+async function main() {
+  try {
+    const accessToken = await getAccessToken();
+    await uploadPackage(accessToken);
+    await publishItem(accessToken);
+    console.log("🎉 Chrome Web Store update completed successfully!");
+  } catch (error) {
+    console.error("❌ Chrome Web Store publish error:", error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This PR adds automated publishing to the Chrome Web Store and Firefox Add-ons (AMO).

- **Chrome**: Adds `scripts/publish-chrome.js` which interacts with Google's Chrome Web Store API v1.1 using OAuth2 refresh tokens.
- **Firefox**: Runs Mozilla's official `web-ext sign` CLI with JWT credentials and uploads the source code zip.
- **Workflow**: Adds `.github/workflows/publish-extension.yml` triggered on published GitHub Releases and manual dispatch (`workflow_dispatch`).
- **Protection**: Adds `.env` to `.gitignore`.